### PR TITLE
fix: Windows path issues

### DIFF
--- a/lua/pendulum/csv.lua
+++ b/lua/pendulum/csv.lua
@@ -42,6 +42,10 @@ end
 ---@param include_header boolean
 function M.write_table_to_csv(filepath, data_table, include_header)
     filepath = filepath:gsub("\\", "\\\\")
+    local d = filepath:match("^(.*[\\/])")
+    if vim.fn.isdirectory(d) == 0 then
+        vim.fn.mkdir(d, "p")
+    end
     local f = io.open(filepath, "a+")
     if not f then
         error("Error opening file: " .. filepath)

--- a/lua/pendulum/csv.lua
+++ b/lua/pendulum/csv.lua
@@ -41,6 +41,7 @@ end
 ---@param data_table table
 ---@param include_header boolean
 function M.write_table_to_csv(filepath, data_table, include_header)
+    filepath = filepath:gsub("\\", "\\\\")
     local f = io.open(filepath, "a+")
     if not f then
         error("Error opening file: " .. filepath)

--- a/lua/pendulum/remote.lua
+++ b/lua/pendulum/remote.lua
@@ -19,7 +19,11 @@ function M.setup(opts)
     -- check os to switch separators and binary extension if necessary
     local uname = vim.loop.os_uname().sysname
     local path_separator = (uname == "Windows_NT") and "\\" or "/"
-    bin_path = plugin_path .. "remote" .. path_separator .. "pendulum-nvim" .. (uname == "Windows_NT" and ".exe" or "")
+    bin_path = plugin_path
+        .. "remote"
+        .. path_separator
+        .. "pendulum-nvim"
+        .. (uname == "Windows_NT" and ".exe" or "")
 
     -- check if binary exists
     local uv = vim.loop

--- a/lua/pendulum/remote.lua
+++ b/lua/pendulum/remote.lua
@@ -13,20 +13,23 @@ function M.setup(opts)
     options.timer_len = opts.timer_len
     options.top_n = opts.top_n or 5
 
+    -- get plugin install path
+    plugin_path = debug.getinfo(1).source:sub(2):match("(.*/).*/.*/")
+
+    -- check os to switch separators and binary extension if necessary
     local uname = vim.loop.os_uname().sysname
     local path_separator = (uname == "Windows_NT") and "\\" or "/"
-    plugin_path = debug.getinfo(1).source:sub(2):match("(.*/).*/.*/")
-    -- FIX: windows binary name is different, figure out how to use it
-
     bin_path = plugin_path .. "remote" .. path_separator .. "pendulum-nvim" .. (uname == "Windows_NT" and ".exe" or "")
 
-    -- check if go binary exists
+    -- check if binary exists
     local uv = vim.loop
     local handle = uv.fs_open(bin_path, "r", 438)
     if handle then
         uv.fs_close(handle)
         return
     end
+
+    -- TODO: check if go is installed and is correct version
 
     -- compile binary if it doesn't exist
     print(

--- a/lua/pendulum/remote.lua
+++ b/lua/pendulum/remote.lua
@@ -13,8 +13,12 @@ function M.setup(opts)
     options.timer_len = opts.timer_len
     options.top_n = opts.top_n or 5
 
+    local uname = vim.loop.os_uname().sysname
+    local path_separator = (uname == "Windows_NT") and "\\" or "/"
     plugin_path = debug.getinfo(1).source:sub(2):match("(.*/).*/.*/")
-    bin_path = plugin_path .. "remote/pendulum-nvim"
+    -- FIX: windows binary name is different, figure out how to use it
+
+    bin_path = plugin_path .. "remote" .. path_separator .. "pendulum-nvim" .. (uname == "Windows_NT" and ".exe" or "")
 
     -- check if go binary exists
     local uv = vim.loop


### PR DESCRIPTION
Attempts to address Windows specific issues relating to handling of file paths and permissions. #2
- Corrects separators for csv log path
- Checks os name to append .exe to report executable if on Windows