### PR TITLE
Configuration options to customise Pendulum report

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ luac.out
 
 ## Extras
 remote/pendulum-nvim
+.luarc.json

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Install Pendulum using your favorite package manager:
 #### With Report Generation (Requires Go)
 
 With lazy.nvim
+
 ```lua
 {
     "ptdewey/pendulum-nvim",
@@ -37,6 +38,7 @@ With lazy.nvim
 #### Without Report Generation
 
 With lazy.nvim
+
 ```lua
 {
     "ptdewey/pendulum-nvim",
@@ -52,13 +54,15 @@ With lazy.nvim
 
 Pendulum can be customized with several options. Here is a table with configurable options:
 
-| Option        | Description                                       | Default                        |
-|---------------|---------------------------------------------------|--------------------------------|
-| `log_file`    | Path to the CSV file where logs should be written | `$HOME/pendulum-log.csv`       |
-| `timeout_len` | Length of time in seconds to determine inactivity | `180`                          |
-| `timer_len`   | Interval in seconds at which to check activity    | `120`                          |
-| `gen_reports` | Generate reports from the log file                | `true`                         |
-| `top_n`       | Number of top entries to include in the report    | `5`                            |
+| Option                      | Description                                             | Default                  |
+|-----------------------------|---------------------------------------------------------|--------------------------|
+| `log_file`                  | Path to the CSV file where logs should be written       | `$HOME/pendulum-log.csv` |
+| `timeout_len`               | Length of time in seconds to determine inactivity       | `180`                    |
+| `timer_len`                 | Interval in seconds at which to check activity          | `120`                    |
+| `gen_reports`               | Generate reports from the log file                      | `true`                   |
+| `top_n`                     | Number of top entries to include in the report          | `5`                      |
+| `report_section_excludes`   | Additional filters to be applied to each report section | `{}`                     |
+| `report_excludes`           | Show/Hide report sections. e.g `branch`, `filetype` ... | `{}`                     |
 
 Example configuration with custom options:
 
@@ -69,8 +73,38 @@ require('pendulum').setup({
     timer_len = 60,     -- 1 minute
     gen_reports = true, -- Enable report generation (requires Go)
     top_n = 10,         -- Include top 10 entries in the report
+    report_section_excludes = {
+        "branch",       -- Hide `branch` section of the report
+        -- Other options includes:
+        -- "directory",
+        -- "filetype",
+        -- "file",
+        -- "project",
+    },
+    report_excludes = {
+        filetype = {
+            -- This table controls what to be excluded from `filetype` section 
+            "neo-tree", -- Exclude neo-tree filetype
+        },
+        file = {
+            -- This table controls what to be excluded from `file` section 
+            "test.py",  -- Exclude any test.py 
+            ".*.go",    -- Exclude all Go files
+        }
+        project = {
+            -- This table controls what to be excluded from `project` section 
+        },
+        directory = {
+            -- This table controls what to be excluded from `directory` section 
+        },
+        branch = {
+            -- This table controls what to be excluded from `branch` section 
+        },
+    },
 })
 ```
+
+**Note**: You can use regex to express the matching patterns within `report_excludes`.
 
 ## Usage
 
@@ -92,7 +126,6 @@ To rebuild the Pendulum binary and generate reports, use the following commands:
 The :PendulumRebuild command recompiles the Go binary, and the :Pendulum command generates the report based on the current log file.
 I recommend rebuilding the binary after the plugin is updated.
 
-
 If you do not want to install Go, report generation can be disabled by changing the `gen_reports` option to `false`. Disabling reports will cause the `Pendulum` and `PendulumRebuild` commands to not be created since they are exclusively used for the reports feature.
 
 ```lua
@@ -113,4 +146,3 @@ These are some potential future ideas that would make for welcome contributions 
 - Get stats for specified project, filetype, etc. (Could work well with Telescope)
 - Nicer looking popup with custom highlight groups
 - Alternative version of popup that uses a terminal buffer and [bubbletea](https://github.com/charmbracelet/bubbletea) (using the table component)
-

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Pendulum can be customized with several options. Here is a table with configurab
 | `gen_reports`               | Generate reports from the log file                      | `true`                   |
 | `top_n`                     | Number of top entries to include in the report          | `5`                      |
 | `report_section_excludes`   | Additional filters to be applied to each report section | `{}`                     |
-| `report_excludes`           | Show/Hide report sections. e.g `branch`, `filetype` ... | `{}`                     |
+| `report_excludes`           | Show/Hide report sections. e.g `branch`, `directory`, `file`, `filetype`, `project` | `{}` |
 
 Example configuration with custom options:
 
@@ -83,22 +83,23 @@ require('pendulum').setup({
     },
     report_excludes = {
         filetype = {
-            -- This table controls what to be excluded from `filetype` section 
+            -- This table controls what to be excluded from `filetype` section
             "neo-tree", -- Exclude neo-tree filetype
         },
         file = {
-            -- This table controls what to be excluded from `file` section 
-            "test.py",  -- Exclude any test.py 
+            -- This table controls what to be excluded from `file` section
+            "test.py",  -- Exclude any test.py
             ".*.go",    -- Exclude all Go files
         }
         project = {
-            -- This table controls what to be excluded from `project` section 
+            -- This table controls what to be excluded from `project` section
+            "unknown_project" -- Exclude unknown (non-git) projects
         },
         directory = {
-            -- This table controls what to be excluded from `directory` section 
+            -- This table controls what to be excluded from `directory` section
         },
         branch = {
-            -- This table controls what to be excluded from `branch` section 
+            -- This table controls what to be excluded from `branch` section
         },
     },
 })
@@ -136,6 +137,8 @@ config = function()
     })
 end,
 ```
+
+The report contents are customizable and section items or entire sections can be excluded from the report if desired. (See `report_excludes` and `report_section_excludes` options in setup)
 
 ## Future Ideas
 

--- a/lua/pendulum/init.lua
+++ b/lua/pendulum/init.lua
@@ -11,11 +11,11 @@ local default_opts = {
     gen_reports = true,
     top_n = 5,
     report_excludes = {
-        filetype = {},
         branch = {},
         directory = {},
-        project = {},
         file = {},
+        filetype = {},
+        project = {},
     },
     report_section_excludes = {},
 }
@@ -24,7 +24,6 @@ local default_opts = {
 ---@param opts table?
 function M.setup(opts)
     opts = vim.tbl_deep_extend("force", default_opts, opts or {})
-    print(opts)
     handlers.setup(opts)
 
     if opts.gen_reports == true then

--- a/lua/pendulum/init.lua
+++ b/lua/pendulum/init.lua
@@ -11,14 +11,12 @@ local default_opts = {
     gen_reports = true,
     top_n = 5,
     report_excludes = {
-        filetypes = {
-            "qf",
-            "TelescopePrompt",
-            "neo-tree",
-        },
-        groups = {
-            "branch",
-        },
+        filetype = {},
+        branch = {},
+        directory = {},
+        project = {},
+        file = {},
+        group = {},
     },
 }
 
@@ -26,6 +24,7 @@ local default_opts = {
 ---@param opts table?
 function M.setup(opts)
     opts = vim.tbl_deep_extend("force", default_opts, opts or {})
+    print(opts)
     handlers.setup(opts)
 
     if opts.gen_reports == true then

--- a/lua/pendulum/init.lua
+++ b/lua/pendulum/init.lua
@@ -10,12 +10,15 @@ local default_opts = {
     timer_len = 120,
     gen_reports = true,
     top_n = 5,
-    sections = {
-        "branch",
-        "directories",
-        "files",
-        "filetypes",
-        "projects",
+    report_excludes = {
+        filetypes = {
+            "qf",
+            "TelescopePrompt",
+            "neo-tree",
+        },
+        groups = {
+            "branch",
+        },
     },
 }
 

--- a/lua/pendulum/init.lua
+++ b/lua/pendulum/init.lua
@@ -16,8 +16,8 @@ local default_opts = {
         directory = {},
         project = {},
         file = {},
-        group = {},
     },
+    report_section_excludes = {},
 }
 
 ---set up plugin autocommands with user options

--- a/lua/pendulum/init.lua
+++ b/lua/pendulum/init.lua
@@ -10,6 +10,13 @@ local default_opts = {
     timer_len = 120,
     gen_reports = true,
     top_n = 5,
+    sections = {
+        "branch",
+        "directories",
+        "files",
+        "filetypes",
+        "projects",
+    },
 }
 
 ---set up plugin autocommands with user options

--- a/lua/pendulum/remote.lua
+++ b/lua/pendulum/remote.lua
@@ -65,7 +65,7 @@ local function setup_pendulum_commands()
             timer_len = options.timer_len,
             top_n = options.top_n,
             time_range = time_range,
-            sections = options.sections,
+            report_excludes = options.report_excludes,
         }
 
         local success, result =
@@ -97,7 +97,7 @@ function M.setup(opts)
     options.log_file = opts.log_file
     options.timer_len = opts.timer_len
     options.top_n = opts.top_n or 5
-    options.sections = opts.sections
+    options.report_excludes = opts.report_excludes
 
     -- get plugin install path
     plugin_path = debug.getinfo(1).source:sub(2):match("(.*/).*/.*/")

--- a/lua/pendulum/remote.lua
+++ b/lua/pendulum/remote.lua
@@ -66,6 +66,7 @@ local function setup_pendulum_commands()
             top_n = options.top_n,
             time_range = time_range,
             report_excludes = options.report_excludes,
+            report_section_excludes = options.report_section_excludes,
         }
 
         local success, result =
@@ -98,6 +99,7 @@ function M.setup(opts)
     options.timer_len = opts.timer_len
     options.top_n = opts.top_n or 5
     options.report_excludes = opts.report_excludes
+    options.report_section_excludes = opts.report_section_excludes
 
     -- get plugin install path
     plugin_path = debug.getinfo(1).source:sub(2):match("(.*/).*/.*/")

--- a/lua/pendulum/remote.lua
+++ b/lua/pendulum/remote.lua
@@ -65,6 +65,7 @@ local function setup_pendulum_commands()
             timer_len = options.timer_len,
             top_n = options.top_n,
             time_range = time_range,
+            sections = options.sections,
         }
 
         local success, result =
@@ -96,6 +97,7 @@ function M.setup(opts)
     options.log_file = opts.log_file
     options.timer_len = opts.timer_len
     options.top_n = opts.top_n or 5
+    options.sections = opts.sections
 
     -- get plugin install path
     plugin_path = debug.getinfo(1).source:sub(2):match("(.*/).*/.*/")
@@ -127,6 +129,7 @@ function M.setup(opts)
             .. bin_path
             .. ", attempting to compile with Go..."
     )
+
     local result =
         os.execute("cd " .. plugin_path .. "remote" .. " && go build")
     if result == 0 then

--- a/remote/internal/metrics.go
+++ b/remote/internal/metrics.go
@@ -25,13 +25,13 @@ type PendulumEntry struct {
 }
 
 var csvColumns = map[string]int{
-	"active":      0,
-	"branch":      1,
-	"directories": 2,
-	"file":        3,
-	"filetype":    4,
-	"project":     5,
-	"time":        6,
+	"active":    0,
+	"branch":    1,
+	"directory": 2,
+	"file":      3,
+	"filetype":  4,
+	"project":   5,
+	"time":      6,
 }
 
 // AggregatePendulumMetrics processes the input data to compute metrics for each column.
@@ -62,7 +62,7 @@ func AggregatePendulumMetrics(
 		}
 
 		is_excluded := false
-		for _, ex := range reportExcludes["groups"].([]interface{}) {
+		for _, ex := range reportExcludes["group"].([]interface{}) {
 			if col == csvColumns[ex.(string)] {
 				is_excluded = true
 				break

--- a/remote/internal/prettify.go
+++ b/remote/internal/prettify.go
@@ -25,7 +25,9 @@ func PrettifyMetrics(metrics []PendulumMetric, n int) []string {
 	// iterate over each metric
 	for _, metric := range metrics {
 		// TODO: redefine order? (might require hardcoding)
-		lines = append(lines, prettifyMetric(metric, n))
+		if metric.Name != "" && len(metric.Value) != 0 {
+			lines = append(lines, prettifyMetric(metric, n))
+		}
 	}
 
 	return lines

--- a/remote/pkg/buffer.go
+++ b/remote/pkg/buffer.go
@@ -56,7 +56,12 @@ func CreateBuffer(v *nvim.Nvim, args PendulumArgs) (nvim.Buffer, error) {
 // Returns:
 // - A 2D slice of bytes representing the text to be set in the buffer.
 func getBufText(data [][]string, args PendulumArgs) [][]byte {
-	out := internal.AggregatePendulumMetrics(data[:], args.Timeout, args.TimeRange, args.Sections)
+	out := internal.AggregatePendulumMetrics(
+		data[:],
+		args.Timeout,
+		args.TimeRange,
+		args.ReportExcludes,
+	)
 	lines := internal.PrettifyMetrics(out, args.TopN)
 
 	var bufText [][]byte

--- a/remote/pkg/buffer.go
+++ b/remote/pkg/buffer.go
@@ -27,7 +27,7 @@ func CreateBuffer(v *nvim.Nvim, args PendulumArgs) (nvim.Buffer, error) {
 	}
 
 	// get prettified buffer text
-	bufText := getBufText(data, args.Timeout, args.TopN, args.TimeRange)
+	bufText := getBufText(data, args)
 
 	// set contents of new buffer
 	if err := v.SetBufferLines(buf, 0, -1, false, bufText); err != nil {
@@ -55,10 +55,9 @@ func CreateBuffer(v *nvim.Nvim, args PendulumArgs) (nvim.Buffer, error) {
 //
 // Returns:
 // - A 2D slice of bytes representing the text to be set in the buffer.
-func getBufText(data [][]string, timeoutLen float64, n int, rangeType string) [][]byte {
-	out := internal.AggregatePendulumMetrics(data, timeoutLen, rangeType)
-
-	lines := internal.PrettifyMetrics(out, n)
+func getBufText(data [][]string, args PendulumArgs) [][]byte {
+	out := internal.AggregatePendulumMetrics(data[:], args.Timeout, args.TimeRange, args.Sections)
+	lines := internal.PrettifyMetrics(out, args.TopN)
 
 	var bufText [][]byte
 	for _, l := range lines {

--- a/remote/pkg/buffer.go
+++ b/remote/pkg/buffer.go
@@ -60,6 +60,7 @@ func getBufText(data [][]string, args PendulumArgs) [][]byte {
 		data[:],
 		args.Timeout,
 		args.TimeRange,
+		args.ReportSectionExcludes,
 		args.ReportExcludes,
 	)
 	lines := internal.PrettifyMetrics(out, args.TopN)

--- a/remote/pkg/utils.go
+++ b/remote/pkg/utils.go
@@ -8,11 +8,12 @@ import (
 // NOTE: add new fields here and to following function to extend functionalities
 // - The fields in this struct should mirror the "command_args" table in `lua/pendulum/remote.lua`
 type PendulumArgs struct {
-	LogFile        string
-	Timeout        float64
-	TopN           int
-	TimeRange      string
-	ReportExcludes map[string]interface{}
+	LogFile               string
+	Timeout               float64
+	TopN                  int
+	TimeRange             string
+	ReportExcludes        map[string]interface{}
+	ReportSectionExcludes []interface{}
 }
 
 // Parse input arguments from lua table args
@@ -47,12 +48,19 @@ func ParsePendlumArgs(args map[string]interface{}) (*PendulumArgs, error) {
 			fmt.Sprintf("Type: %T\n", args["report_excludes"]))
 	}
 
+	reportSectionExcludes, ok := args["report_section_excludes"].([]interface{})
+	if !ok {
+		return nil, errors.New("report_excludes missing or not a list. " +
+			fmt.Sprintf("Type: %T\n", args["report_section_excludes"]))
+	}
+
 	out := PendulumArgs{
-		LogFile:        logFile,
-		Timeout:        float64(timerLen),
-		TopN:           int(topN),
-		TimeRange:      timeRange,
-		ReportExcludes: reportExcludes,
+		LogFile:               logFile,
+		Timeout:               float64(timerLen),
+		TopN:                  int(topN),
+		TimeRange:             timeRange,
+		ReportExcludes:        reportExcludes,
+		ReportSectionExcludes: reportSectionExcludes,
 	}
 
 	return &out, nil

--- a/remote/pkg/utils.go
+++ b/remote/pkg/utils.go
@@ -8,10 +8,11 @@ import (
 // NOTE: add new fields here and to following function to extend functionalities
 // - The fields in this struct should mirror the "command_args" table in `lua/pendulum/remote.lua`
 type PendulumArgs struct {
-	LogFile   string
-	Timeout   float64
-	TopN      int
-	TimeRange string
+	LogFile          string
+	Timeout          float64
+	TopN             int
+	TimeRange        string
+	Sections         []interface{}
 }
 
 // Parse input arguments from lua table args
@@ -40,11 +41,18 @@ func ParsePendlumArgs(args map[string]interface{}) (*PendulumArgs, error) {
 			fmt.Sprintf("Type: %T\n", args["time_range"]))
 	}
 
+	sections, ok := args["sections"].([]interface{})
+	if !ok {
+		return nil, errors.New("sections missing or not an array. " +
+			fmt.Sprintf("Type: %T\n", args["sections"]))
+	}
+
 	out := PendulumArgs{
-		LogFile:   logFile,
-		Timeout:   float64(timerLen),
-		TopN:      int(topN),
-		TimeRange: timeRange,
+		LogFile:          logFile,
+		Timeout:          float64(timerLen),
+		TopN:             int(topN),
+		TimeRange:        timeRange,
+		Sections:         sections,
 	}
 
 	return &out, nil

--- a/remote/pkg/utils.go
+++ b/remote/pkg/utils.go
@@ -8,11 +8,11 @@ import (
 // NOTE: add new fields here and to following function to extend functionalities
 // - The fields in this struct should mirror the "command_args" table in `lua/pendulum/remote.lua`
 type PendulumArgs struct {
-	LogFile          string
-	Timeout          float64
-	TopN             int
-	TimeRange        string
-	Sections         []interface{}
+	LogFile        string
+	Timeout        float64
+	TopN           int
+	TimeRange      string
+	ReportExcludes map[string]interface{}
 }
 
 // Parse input arguments from lua table args
@@ -41,18 +41,18 @@ func ParsePendlumArgs(args map[string]interface{}) (*PendulumArgs, error) {
 			fmt.Sprintf("Type: %T\n", args["time_range"]))
 	}
 
-	sections, ok := args["sections"].([]interface{})
+	reportExcludes, ok := args["report_excludes"].(map[string]interface{})
 	if !ok {
-		return nil, errors.New("sections missing or not an array. " +
-			fmt.Sprintf("Type: %T\n", args["sections"]))
+		return nil, errors.New("report_excludes missing or not an map. " +
+			fmt.Sprintf("Type: %T\n", args["report_excludes"]))
 	}
 
 	out := PendulumArgs{
-		LogFile:          logFile,
-		Timeout:          float64(timerLen),
-		TopN:             int(topN),
-		TimeRange:        timeRange,
-		Sections:         sections,
+		LogFile:        logFile,
+		Timeout:        float64(timerLen),
+		TopN:           int(topN),
+		TimeRange:      timeRange,
+		ReportExcludes: reportExcludes,
 	}
 
 	return &out, nil


### PR DESCRIPTION
closes #10 

This PR introduces two new configuration fields to the plugin: 

- `sections` toggles show/hide report section(s) (branch, project, file, filetypes, directories). 
- `exclude_filetypes` allows users to filter out certain filetypes from their report. e.g. `neo-tree`, `qf` or `TelescopePrompt` 
