### PR TITLE
bug: ignore metric points with NaN ActivePct value

### DIFF
--- a/remote/internal/prettify.go
+++ b/remote/internal/prettify.go
@@ -2,6 +2,7 @@ package internal
 
 import (
 	"fmt"
+	"math"
 	"sort"
 
 	"golang.org/x/text/cases"
@@ -70,6 +71,10 @@ func prettifyMetric(metric PendulumMetric, n int) string {
 	name := cases.Title(language.English, cases.Compact).String(metric.Name)
 	out := fmt.Sprintf("# Top %d %s:\n", n, prettifyMetricName(name))
 	for i := 0; i < n; i++ {
+		if math.IsNaN(float64(metric.Value[keys[i]].ActivePct)) {
+			continue
+		}
+
 		out = fmt.Sprintln(out, prettifyEntry(metric.Value[keys[i]], i, l, n))
 	}
 


### PR DESCRIPTION
While working on the previous PR, this stuck out to me:

Current:
![Screenshot from 2024-10-21 09-37-24](https://github.com/user-attachments/assets/e46b3c86-f6e6-41a2-aeb5-5c28d1c213eb)

notice the `~/.` entry showing `NaN %`

This is caused by: 
![Screenshot from 2024-10-21 09-37-48](https://github.com/user-attachments/assets/598cc37f-4c88-46bd-8784-9907b3833209)
This entry in my `report.csv` doesn't have a matching end entry. I do not manually edit this file.
I'm not entirely sure why yet. 

After applying patch:
![Screenshot from 2024-10-21 09-38-18](https://github.com/user-attachments/assets/6bfcc1d2-2964-4d47-94c4-430712a0c127)
